### PR TITLE
Update power_limit on rm_chassis_controllers

### DIFF
--- a/rm_chassis_controllers/config/standard4.yaml
+++ b/rm_chassis_controllers/config/standard4.yaml
@@ -12,10 +12,10 @@ controllers:
     enable_odom_tf: true
     power_limit:
       - joint:
-          - "right_front_wheel_motor"
-          - "left_front_wheel_motor"
-          - "left_back_wheel_motor"
-          - "right_back_wheel_motor"
+          - "right_front_wheel_joint"
+          - "left_front_wheel_joint"
+          - "left_back_wheel_joint"
+          - "right_back_wheel_joint"
         effort_coeff: 12.0
         vel_coeff: 0.0048
         power_offset: -3.

--- a/rm_chassis_controllers/config/standard4.yaml
+++ b/rm_chassis_controllers/config/standard4.yaml
@@ -10,10 +10,19 @@ controllers:
     type: rm_chassis_controllers/SwerveController
     publish_rate: 100
     enable_odom_tf: true
-    power:
-      effort_coeff: 12.0
-      vel_coeff: 0.0048
-      power_offset: -3
+    power_limit:
+      - joint:
+          - "right_front_wheel_motor"
+          - "left_front_wheel_motor"
+          - "left_back_wheel_motor"
+          - "right_back_wheel_motor"
+        effort_coeff: 12.0
+        vel_coeff: 0.0048
+        power_offset: -3.
+      - keyword: "pivot"
+        effort_coeff: 12.0
+        vel_coeff: 0.0048
+        power_offset: -3.
     timeout: 0.1
     twist_covariance_diagonal: [ 0.001, 0.001, 0.001, 0.001, 0.001, 0.001 ]
     pid_follow: { p: 5, i: 0, d: 0.0, i_max: 0.0, i_min: 0.0, antiwindup: true, publish_state: true }

--- a/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
@@ -129,11 +129,6 @@ protected:
    * @param from The father frame.
    */
   void tfVelToBase(const std::string& from);
-  /** @brief To limit the chassis power according to current power limit.
-   *
-   * Receive power limit from command. Set max_effort command to chassis to avoid exceed power limit.
-   */
-  void powerLimit();
   /** @brief Write current command from rm_msgs::ChassisCmd.
    *
    * @param msg This message contains various state parameter settings for basic chassis control

--- a/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
@@ -47,6 +47,7 @@
 #include <geometry_msgs/TwistStamped.h>
 #include <geometry_msgs/Vector3Stamped.h>
 #include <nav_msgs/Odometry.h>
+#include "rm_chassis_controllers/power_limit.h"
 
 namespace rm_chassis_controllers
 {
@@ -113,7 +114,11 @@ protected:
    * The mode GYRO: Chassis will rotate around itself.
    */
   void gyro();
-  virtual void moveJoint(const ros::Time& time, const ros::Duration& period) = 0;
+  virtual void moveJoint(const ros::Time& time, const ros::Duration& period)
+  {
+    for (auto& power_limit : power_limits_)
+      power_limit.limit();
+  }
   virtual geometry_msgs::Twist forwardKinematics() = 0;
   /** @brief Init frame on base_link. Integral vel to pos and angle.
    *
@@ -143,6 +148,7 @@ protected:
   rm_control::RobotStateHandle robot_state_handle_{};
   hardware_interface::EffortJointInterface* effort_joint_interface_{};
   std::vector<hardware_interface::JointHandle> joint_handles_{};
+  std::vector<PowerLimit> power_limits_{};
 
   double wheel_base_{}, wheel_track_{}, wheel_radius_{}, publish_rate_{}, twist_angular_{}, timeout_{}, effort_coeff_{},
       velocity_coeff_{}, power_offset_{};

--- a/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/chassis_base.h
@@ -116,8 +116,9 @@ protected:
   void gyro();
   virtual void moveJoint(const ros::Time& time, const ros::Duration& period)
   {
+    double power_limit_ = cmd_rt_buffer_.readFromRT()->cmd_chassis_.power_limit;
     for (auto& power_limit : power_limits_)
-      power_limit.limit();
+      power_limit.limit(power_limit_);
   }
   virtual geometry_msgs::Twist forwardKinematics() = 0;
   /** @brief Init frame on base_link. Integral vel to pos and angle.

--- a/rm_chassis_controllers/include/rm_chassis_controllers/power_limit.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/power_limit.h
@@ -1,0 +1,75 @@
+//
+// Created by ljq on 2021/12/21.
+//
+
+#pragma once
+
+#include <rm_common/math_utilities.h>
+namespace rm_chassis_controllers
+{
+class PowerLimit
+{
+public:
+  explicit PowerLimit(XmlRpc::XmlRpcValue xml_value, hardware_interface::EffortJointInterface& hardware_interface)
+  {
+    if (xml_value.hasMember("keyword"))
+    {
+      for (long unsigned int j = 0; j < hardware_interface.getNames().size(); j++)
+      {
+        std::string keyword_name_ = xml_value["keyword"];
+        if (hardware_interface.getNames()[j].find(keyword_name_) != std::string::npos)
+        {
+          effort_coeff_ = xml_value["effort_coeff"];
+          vel_coeff_ = xml_value["vel_coeff"];
+          power_offset_ = xml_value["power_offset"];
+          joint_handles_.push_back(hardware_interface.getHandle(hardware_interface.getNames()[j]));
+        }
+      }
+    }
+    else if (xml_value.hasMember("joint"))
+    {
+      for (long unsigned int j = 0; j < hardware_interface.getNames().size(); j++)
+      {
+        for (int k = 0; k < xml_value["joint"].size(); k++)
+        {
+          std::string joint_name_ = xml_value["joint"][k];
+          if (hardware_interface.getNames()[j] == joint_name_)
+          {
+            effort_coeff_ = xml_value["effort_coeff"];
+            vel_coeff_ = xml_value["vel_coeff"];
+            power_offset_ = xml_value["power_offset"];
+            joint_handles_.push_back(hardware_interface.getHandle(joint_name_));
+          }
+        }
+      }
+    }
+  }
+
+  void limit()
+  {
+    double power_limit = 60;
+    // Three coefficients of a quadratic equation in one variable
+    double a = 0., b = 0., c = 0.;
+    for (const auto& joint : joint_handles_)
+    {
+      double cmd_effort = joint.getCommand();
+      double real_vel = joint.getVelocity();
+      a += square(cmd_effort);
+      b += std::abs(cmd_effort * real_vel);
+      c += square(real_vel);
+    }
+    a *= effort_coeff_;
+    c = c * vel_coeff_ - power_offset_ - power_limit;
+    // Root formula for quadratic equation in one variable
+    double zoom_coeff = (square(b) - 4 * a * c) > 0 ? ((-b + sqrt(square(b) - 4 * a * c)) / (2 * a)) : 0.;
+    for (auto joint : joint_handles_)
+    {
+      joint.setCommand(zoom_coeff > 1 ? joint.getCommand() : joint.getCommand() * zoom_coeff);
+      std::cout << joint.getName() << std::endl;
+    }
+  }
+
+  double effort_coeff_, vel_coeff_, power_offset_;
+  std::vector<hardware_interface::JointHandle> joint_handles_;
+};
+}  // namespace rm_chassis_controllers

--- a/rm_chassis_controllers/include/rm_chassis_controllers/power_limit.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/power_limit.h
@@ -45,9 +45,8 @@ public:
     }
   }
 
-  void limit()
+  void limit(double power_limit)
   {
-    double power_limit = 60;
     // Three coefficients of a quadratic equation in one variable
     double a = 0., b = 0., c = 0.;
     for (const auto& joint : joint_handles_)
@@ -65,7 +64,6 @@ public:
     for (auto joint : joint_handles_)
     {
       joint.setCommand(zoom_coeff > 1 ? joint.getCommand() : joint.getCommand() * zoom_coeff);
-      std::cout << joint.getName() << std::endl;
     }
   }
 

--- a/rm_chassis_controllers/src/chassis_base.cpp
+++ b/rm_chassis_controllers/src/chassis_base.cpp
@@ -52,10 +52,7 @@ template <typename... T>
 bool ChassisBase<T...>::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& root_nh,
                              ros::NodeHandle& controller_nh)
 {
-  if (!controller_nh.getParam("publish_rate", publish_rate_) || !controller_nh.getParam("timeout", timeout_) ||
-      !controller_nh.getParam("power/vel_coeff", velocity_coeff_) ||
-      !controller_nh.getParam("power/effort_coeff", effort_coeff_) ||
-      !controller_nh.getParam("power/power_offset", power_offset_))
+  if (!controller_nh.getParam("publish_rate", publish_rate_) || !controller_nh.getParam("timeout", timeout_))
   {
     ROS_ERROR("Some chassis params doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
     return false;
@@ -165,7 +162,6 @@ void ChassisBase<T...>::update(const ros::Time& time, const ros::Duration& perio
   vel_cmd_.z = ramp_w_->output();
 
   moveJoint(time, period);
-  powerLimit();
 }
 
 template <typename... T>
@@ -328,34 +324,6 @@ void ChassisBase<T...>::recovery()
   ramp_x_->clear(vel_cmd_.x);
   ramp_y_->clear(vel_cmd_.y);
   ramp_w_->clear(vel_cmd_.z);
-}
-
-template <typename... T>
-void ChassisBase<T...>::powerLimit()
-{
-  double power_limit = cmd_rt_buffer_.readFromRT()->cmd_chassis_.power_limit;
-  // Three coefficients of a quadratic equation in one variable
-  double a = 0., b = 0., c = 0.;
-  for (const auto& joint : joint_handles_)
-  {
-    double cmd_effort = joint.getCommand();
-    double real_vel = joint.getVelocity();
-    if (joint.getName().find("wheel") != std::string::npos)  // The pivot joint of swerve drive doesn't need power limit
-    {
-      a += square(cmd_effort);
-      b += std::abs(cmd_effort * real_vel);
-      c += square(real_vel);
-    }
-  }
-  a *= effort_coeff_;
-  c = c * velocity_coeff_ - power_offset_ - power_limit;
-  // Root formula for quadratic equation in one variable
-  double zoom_coeff = (square(b) - 4 * a * c) > 0 ? ((-b + sqrt(square(b) - 4 * a * c)) / (2 * a)) : 0.;
-  for (auto joint : joint_handles_)
-    if (joint.getName().find("wheel") != std::string::npos)
-    {
-      joint.setCommand(zoom_coeff > 1 ? joint.getCommand() : joint.getCommand() * zoom_coeff);
-    }
 }
 
 template <typename... T>

--- a/rm_chassis_controllers/src/chassis_base.cpp
+++ b/rm_chassis_controllers/src/chassis_base.cpp
@@ -74,6 +74,14 @@ bool ChassisBase<T...>::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   robot_state_handle_ = robot_hw->get<rm_control::RobotStateInterface>()->getHandle("robot_state");
   effort_joint_interface_ = robot_hw->get<hardware_interface::EffortJointInterface>();
 
+  XmlRpc::XmlRpcValue xml_value;
+  controller_nh.getParam("power_limit", xml_value);
+  ROS_ASSERT(xml_value.getType() == XmlRpc::XmlRpcValue::Type::TypeArray);
+  for (int i = 0; i < xml_value.size(); i++)
+  {
+    power_limits_.push_back(PowerLimit(xml_value[i], *effort_joint_interface_));
+  }
+
   // Setup odometry realtime publisher + odom message constant fields
   odom_pub_.reset(new realtime_tools::RealtimePublisher<nav_msgs::Odometry>(root_nh, "odom", 100));
   odom_pub_->msg_.header.frame_id = "odom";

--- a/rm_chassis_controllers/src/mecanum.cpp
+++ b/rm_chassis_controllers/src/mecanum.cpp
@@ -70,6 +70,7 @@ void MecanumController::moveJoint(const ros::Time& time, const ros::Duration& pe
   ctrl_rf_.update(time, period);
   ctrl_lb_.update(time, period);
   ctrl_rb_.update(time, period);
+  ChassisBase::moveJoint(time, period);
 }
 
 geometry_msgs::Twist MecanumController::forwardKinematics()

--- a/rm_chassis_controllers/src/swerve.cpp
+++ b/rm_chassis_controllers/src/swerve.cpp
@@ -97,6 +97,7 @@ void SwerveController::moveJoint(const ros::Time& time, const ros::Duration& per
     module.ctrl_pivot_->update(time, period);
     module.ctrl_wheel_->update(time, period);
   }
+  ChassisBase::moveJoint(time, period);
 }
 
 geometry_msgs::Twist SwerveController::forwardKinematics()


### PR DESCRIPTION
我这次才知道hardware_interface可以直接getname用之前不知道所以一直不知道怎么处理。。这次的话我把power_limits的push过程放在了chass_base.cpp里面，然后通过循环power_limit的xml去push一组进去。然后可以实现就只在对应底盘如（swerve.cpp）里加一行代码就可以实现功率限制，测试了hero还有balance，这些都可以。。然后还测试了在yaml中加入弹仓盖的关键词“cover”还有摩擦轮，在不修改cpp代码的前提下，可以实现他们的功率限制（仿真下用rosinfo测试的），然后加入不存在的比如“qwiod”的时候，不修改代码的前提下，不会进入功率限制。