### PR TITLE
Add feedforward in gimbal control

### DIFF
--- a/rm_gimbal_controllers/CMakeLists.txt
+++ b/rm_gimbal_controllers/CMakeLists.txt
@@ -10,6 +10,8 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_definitions(-Wall -Werror)
 
 ## Find catkin macros and libraries
+find_package(Eigen3 REQUIRED)
+
 find_package(catkin REQUIRED
         COMPONENTS
         roscpp
@@ -47,6 +49,7 @@ generate_dynamic_reconfigure_options(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
         INCLUDE_DIRS
+        ${EIGEN3_INCLUDE_DIR}
         include
         LIBRARIES
         CATKIN_DEPENDS
@@ -79,6 +82,7 @@ catkin_package(
 include_directories(
         include
         ${catkin_INCLUDE_DIRS}
+        ${EIGEN3_INCLUDE_DIR}
 )
 
 ## Declare a cpp library

--- a/rm_gimbal_controllers/CMakeLists.txt
+++ b/rm_gimbal_controllers/CMakeLists.txt
@@ -10,7 +10,6 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
 add_definitions(-Wall -Werror)
 
 ## Find catkin macros and libraries
-find_package(Eigen3 REQUIRED)
 
 find_package(catkin REQUIRED
         COMPONENTS
@@ -28,6 +27,7 @@ find_package(catkin REQUIRED
         control_toolbox
         effort_controllers
         tf2
+        tf2_eigen
         tf2_geometry_msgs
         visualization_msgs
         dynamic_reconfigure
@@ -49,7 +49,6 @@ generate_dynamic_reconfigure_options(
 ## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
         INCLUDE_DIRS
-        ${EIGEN3_INCLUDE_DIR}
         include
         LIBRARIES
         CATKIN_DEPENDS
@@ -67,6 +66,7 @@ catkin_package(
         control_toolbox
         effort_controllers
         tf2
+        tf2_eigen
         tf2_geometry_msgs
         visualization_msgs
         dynamic_reconfigure
@@ -82,7 +82,6 @@ catkin_package(
 include_directories(
         include
         ${catkin_INCLUDE_DIRS}
-        ${EIGEN3_INCLUDE_DIR}
 )
 
 ## Declare a cpp library

--- a/rm_gimbal_controllers/config/engineer.yaml
+++ b/rm_gimbal_controllers/config/engineer.yaml
@@ -16,6 +16,10 @@ controllers:
     pitch:
       joint: "pitch_joint"
       pid: { p: 0.8, i: 0.0, d: 0.03, i_clamp_max: 0.0, i_clamp_min: -0.0, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.45
       resistance_coff_qd_15: 1.0

--- a/rm_gimbal_controllers/config/hero.yaml
+++ b/rm_gimbal_controllers/config/hero.yaml
@@ -17,6 +17,10 @@ controllers:
     pitch:
       joint: "pitch_joint"
       pid: { p: 20, i: 200, d: 0.4, i_clamp_max: 0.8, i_clamp_min: -0.8, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.1
       resistance_coff_qd_15: 0.4

--- a/rm_gimbal_controllers/config/sentry.yaml
+++ b/rm_gimbal_controllers/config/sentry.yaml
@@ -19,6 +19,10 @@ controllers:
     pitch:
       joint: "upper_pitch_joint"
       pid: { p: 8.0, i: 50, d: 0.3, i_clamp_max: 0.1, i_clamp_min: -0.1, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.45
       resistance_coff_qd_15: 0.4

--- a/rm_gimbal_controllers/config/standard3.yaml
+++ b/rm_gimbal_controllers/config/standard3.yaml
@@ -13,6 +13,10 @@ controllers:
     pitch:
       joint: "pitch_joint"
       pid: { p: 15, i: 50, d: 0.3, i_clamp_max: 0.4, i_clamp_min: -0.4, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.45
       resistance_coff_qd_15: 1.0

--- a/rm_gimbal_controllers/config/standard4.yaml
+++ b/rm_gimbal_controllers/config/standard4.yaml
@@ -12,7 +12,11 @@ controllers:
       pid: { p: 8, i: 0, d: 0.4, i_clamp_max: 0.0, i_clamp_min: -0.0, antiwindup: true, publish_state: true }
     pitch:
       joint: "pitch_joint"
-      pid: { p: 10, i: 50, d: 0.3, i_clamp_max: 0.4, i_clamp_min: -0.4, antiwindup: true, publish_state: true }
+      pid: { p: 20.0, i: 1, d: 0.45, i_clamp_max: 0.4, i_clamp_min: -0.4, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.45
       resistance_coff_qd_15: 0.1

--- a/rm_gimbal_controllers/config/standard5.yaml
+++ b/rm_gimbal_controllers/config/standard5.yaml
@@ -8,6 +8,10 @@ controllers:
     pitch:
       joint: "pitch_joint"
       pid: { p: 20.0, i: 1, d: 0.45, i_clamp_max: 0.4, i_clamp_min: -0.4, antiwindup: true, publish_state: true }
+    feedforward:
+      gravity: 0.0
+      enable_gravity_compensation: false
+      mass_origin: [ 0.0,0.0,0.0 ]
     bullet_solver:
       resistance_coff_qd_10: 0.45
       resistance_coff_qd_15: 1.0

--- a/rm_gimbal_controllers/include/rm_gimbal_controllers/gimbal_base.h
+++ b/rm_gimbal_controllers/include/rm_gimbal_controllers/gimbal_base.h
@@ -47,6 +47,8 @@
 #include <rm_msgs/GimbalDesError.h>
 #include <dynamic_reconfigure/server.h>
 #include <rm_gimbal_controllers/bullet_solver.h>
+#include <tf2_eigen/tf2_eigen.h>
+#include <Eigen/Eigen>
 
 namespace rm_gimbal_controllers
 {
@@ -66,6 +68,7 @@ private:
   void track(const ros::Time& time);
   void direct(const ros::Time& time);
   void moveJoint(const ros::Time& time, const ros::Duration& period);
+  double feedForward(const ros::Time& time);
   void commandCB(const rm_msgs::GimbalCmdConstPtr& msg);
 
   rm_control::RobotStateHandle robot_state_handle_;
@@ -87,6 +90,10 @@ private:
 
   double publish_rate_{};
   bool state_changed_{};
+
+  geometry_msgs::Vector3 mass_origin_;
+  double gravity_;
+  bool enable_gravity_compensation_;
 
   enum
   {

--- a/rm_gimbal_controllers/package.xml
+++ b/rm_gimbal_controllers/package.xml
@@ -24,6 +24,7 @@
     <depend>control_toolbox</depend>
     <depend>effort_controllers</depend>
     <depend>tf2</depend>
+    <depend>tf2_eigen</depend>
     <depend>tf2_geometry_msgs</depend>
     <depend>visualization_msgs</depend>
     <depend>dynamic_reconfigure</depend>


### PR DESCRIPTION
从urdf读质心位置和质量在仿真会出问题，而且感觉不太优雅，最后还是采取了从配置文件读参数的方法。

加前馈前
![加前馈前](https://ftp.bmp.ovh/imgs/2021/12/0f6aa1058c184002.gif)
平地加前馈后
![](https://ftp.bmp.ovh/imgs/2021/12/214dd9551ffdd41b.gif)
底盘倾斜，yaw转动，加前馈后
![](https://ftp.bmp.ovh/imgs/2021/12/95653165f3514d99.gif)