### PR TITLE
Fix failure to find effort_controllers when building mimic_joint_controller

### DIFF
--- a/mimic_joint_controller/CMakeLists.txt
+++ b/mimic_joint_controller/CMakeLists.txt
@@ -3,7 +3,8 @@ project(mimic_joint_controller)
 
 find_package(catkin REQUIRED COMPONENTS
         roscpp
-
+        effort_controllers
+        hardware_interface
         pluginlib
         controller_interface
         )
@@ -13,7 +14,8 @@ catkin_package(
         include
         CATKIN_DEPENDS
         roscpp
-
+        effort_controllers
+        hardware_interface
         pluginlib
         controller_interface
         LIBRARIES ${PROJECT_NAME}

--- a/mimic_joint_controller/package.xml
+++ b/mimic_joint_controller/package.xml
@@ -12,6 +12,8 @@
   <depend>pluginlib</depend>
   <depend>roscpp</depend>
   <depend>controller_interface</depend>
+  <depend>effort_controllers</depend>
+  <depend>hardware_interface</depend>
 
   <export>
     <controller_interface plugin="${prefix}/mimic_joint_controller_plugins.xml"/>


### PR DESCRIPTION
This fixes a build failure on all platforms on the ROS Noetic buildfarm: https://build.ros.org/job/Nbin_uF64__mimic_joint_controller__ubuntu_focal_amd64__binary/197/console

```
23:15:30 [ 50%] Building CXX object CMakeFiles/mimic_joint_controller.dir/src/mimic_joint_controller.cpp.o
23:15:30 /usr/lib/ccache/c++  -DROSCONSOLE_BACKEND_LOG4CXX -DROS_BUILD_SHARED_LIBS=1 -DROS_PACKAGE_NAME=\"mimic_joint_controller\" -Dmimic_joint_controller_EXPORTS -I/tmp/binarydeb/ros-noetic-mimic-joint-controller-0.1.7/include -I/opt/ros/noetic/include -I/opt/ros/noetic/share/xmlrpcpp/cmake/../../../include/xmlrpcpp  -g -O2 -fdebug-prefix-map=/tmp/binarydeb/ros-noetic-mimic-joint-controller-0.1.7=. -fstack-protector-strong -Wformat -Werror=format-security -DNDEBUG -Wdate-time -D_FORTIFY_SOURCE=2 -fPIC   -o CMakeFiles/mimic_joint_controller.dir/src/mimic_joint_controller.cpp.o -c /tmp/binarydeb/ros-noetic-mimic-joint-controller-0.1.7/src/mimic_joint_controller.cpp
23:15:30 In file included from /tmp/binarydeb/ros-noetic-mimic-joint-controller-0.1.7/src/mimic_joint_controller.cpp:5:
23:15:31 /tmp/binarydeb/ros-noetic-mimic-joint-controller-0.1.7/include/mimic_joint_controller/mimic_joint_controller.h:9:10: fatal error: effort_controllers/joint_position_controller.h: No such file or directory
23:15:31     9 | #include <effort_controllers/joint_position_controller.h>
23:15:31       |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
23:15:31 compilation terminated.
```




Likely culprit is #81 removing the dependency on `hardware_interface`.  `mimic_joint_controller` includes on headers from `effort_controllers` and `hardware_interface`, so it must have dependencies on them too.

https://github.com/rm-controls/rm_controllers/blob/9c8058bfcd526c70568ef094e92256d6e22a1cec/mimic_joint_controller/include/mimic_joint_controller/mimic_joint_controller.h#L8-L9