### PR TITLE
Fixed the bug of gimbal warning

### DIFF
--- a/rm_gimbal_controllers/src/gimbal_base.cpp
+++ b/rm_gimbal_controllers/src/gimbal_base.cpp
@@ -362,21 +362,24 @@ void Controller::moveJoint(const ros::Time& time, const ros::Duration& period)
 
     try
     {
-      geometry_msgs::TransformStamped transform = robot_state_handle_.lookupTransform(
-          ctrl_yaw_.joint_urdf_->parent_link_name, data_track_.header.frame_id, data_track_.header.stamp);
-      tf2::doTransform(target_pos, target_pos, transform);
-      tf2::doTransform(target_vel, target_vel, transform);
-      tf2::fromMsg(target_pos, target_pos_tf);
-      tf2::fromMsg(target_vel, target_vel_tf);
+      if (!data_track_.header.frame_id.empty())
+      {
+        geometry_msgs::TransformStamped transform = robot_state_handle_.lookupTransform(
+            ctrl_yaw_.joint_urdf_->parent_link_name, data_track_.header.frame_id, data_track_.header.stamp);
+        tf2::doTransform(target_pos, target_pos, transform);
+        tf2::doTransform(target_vel, target_vel, transform);
+        tf2::fromMsg(target_pos, target_pos_tf);
+        tf2::fromMsg(target_vel, target_vel_tf);
 
-      yaw_vel_des = target_vel_tf.cross(target_pos_tf).z() / std::pow((target_pos_tf.length()), 2);
-      transform = robot_state_handle_.lookupTransform(ctrl_pitch_.joint_urdf_->parent_link_name,
-                                                      data_track_.header.frame_id, data_track_.header.stamp);
-      tf2::doTransform(target_pos, target_pos, transform);
-      tf2::doTransform(target_vel, target_vel, transform);
-      tf2::fromMsg(target_pos, target_pos_tf);
-      tf2::fromMsg(target_vel, target_vel_tf);
-      pitch_vel_des = target_vel_tf.cross(target_pos_tf).y() / std::pow((target_pos_tf.length()), 2);
+        yaw_vel_des = target_vel_tf.cross(target_pos_tf).z() / std::pow((target_pos_tf.length()), 2);
+        transform = robot_state_handle_.lookupTransform(ctrl_pitch_.joint_urdf_->parent_link_name,
+                                                        data_track_.header.frame_id, data_track_.header.stamp);
+        tf2::doTransform(target_pos, target_pos, transform);
+        tf2::doTransform(target_vel, target_vel, transform);
+        tf2::fromMsg(target_pos, target_pos_tf);
+        tf2::fromMsg(target_vel, target_vel_tf);
+        pitch_vel_des = target_vel_tf.cross(target_pos_tf).y() / std::pow((target_pos_tf.length()), 2);
+      }
     }
     catch (tf2::TransformException& ex)
     {

--- a/rm_gimbal_controllers/src/gimbal_base.cpp
+++ b/rm_gimbal_controllers/src/gimbal_base.cpp
@@ -354,7 +354,7 @@ void Controller::moveJoint(const ros::Time& time, const ros::Duration& period)
     yaw_vel_des = cmd_gimbal_.rate_yaw;
     pitch_vel_des = cmd_gimbal_.rate_pitch;
   }
-  else
+  else if (state_ == TRACK)
   {
     geometry_msgs::Point target_pos = data_track_.target_pos;
     geometry_msgs::Vector3 target_vel = data_track_.target_vel;
@@ -362,24 +362,21 @@ void Controller::moveJoint(const ros::Time& time, const ros::Duration& period)
 
     try
     {
-      if (!data_track_.header.frame_id.empty())
-      {
-        geometry_msgs::TransformStamped transform = robot_state_handle_.lookupTransform(
-            ctrl_yaw_.joint_urdf_->parent_link_name, data_track_.header.frame_id, data_track_.header.stamp);
-        tf2::doTransform(target_pos, target_pos, transform);
-        tf2::doTransform(target_vel, target_vel, transform);
-        tf2::fromMsg(target_pos, target_pos_tf);
-        tf2::fromMsg(target_vel, target_vel_tf);
+      geometry_msgs::TransformStamped transform = robot_state_handle_.lookupTransform(
+          ctrl_yaw_.joint_urdf_->parent_link_name, data_track_.header.frame_id, data_track_.header.stamp);
+      tf2::doTransform(target_pos, target_pos, transform);
+      tf2::doTransform(target_vel, target_vel, transform);
+      tf2::fromMsg(target_pos, target_pos_tf);
+      tf2::fromMsg(target_vel, target_vel_tf);
 
-        yaw_vel_des = target_vel_tf.cross(target_pos_tf).z() / std::pow((target_pos_tf.length()), 2);
-        transform = robot_state_handle_.lookupTransform(ctrl_pitch_.joint_urdf_->parent_link_name,
-                                                        data_track_.header.frame_id, data_track_.header.stamp);
-        tf2::doTransform(target_pos, target_pos, transform);
-        tf2::doTransform(target_vel, target_vel, transform);
-        tf2::fromMsg(target_pos, target_pos_tf);
-        tf2::fromMsg(target_vel, target_vel_tf);
-        pitch_vel_des = target_vel_tf.cross(target_pos_tf).y() / std::pow((target_pos_tf.length()), 2);
-      }
+      yaw_vel_des = target_vel_tf.cross(target_pos_tf).z() / std::pow((target_pos_tf.length()), 2);
+      transform = robot_state_handle_.lookupTransform(ctrl_pitch_.joint_urdf_->parent_link_name,
+                                                      data_track_.header.frame_id, data_track_.header.stamp);
+      tf2::doTransform(target_pos, target_pos, transform);
+      tf2::doTransform(target_vel, target_vel, transform);
+      tf2::fromMsg(target_pos, target_pos_tf);
+      tf2::fromMsg(target_vel, target_vel_tf);
+      pitch_vel_des = target_vel_tf.cross(target_pos_tf).y() / std::pow((target_pos_tf.length()), 2);
     }
     catch (tf2::TransformException& ex)
     {


### PR DESCRIPTION
当在工程上使用direct模式的时候，会不断报warnning,内容是不能使用空的target frame id，经过排查后发现是这里的data_track_的frame_id为空的原因，所以加入了一个empty判断。经过测试，解决了工程上的云台warnning问题。