### PR TITLE
Add follow gimbal's chassis control

### DIFF
--- a/rm_chassis_controllers/src/chassis_base.cpp
+++ b/rm_chassis_controllers/src/chassis_base.cpp
@@ -269,7 +269,6 @@ void ChassisBase<T...>::raw()
 
     recovery();
   }
-  tfVelToBase(command_source_frame_);
 }
 
 template <typename... T>

--- a/rm_chassis_controllers/src/chassis_base.cpp
+++ b/rm_chassis_controllers/src/chassis_base.cpp
@@ -217,12 +217,12 @@ void ChassisBase<T...>::twist(const ros::Time& time, const ros::Duration& period
     recovery();
     pid_follow_.reset();
   }
-  tfVelToBase("yaw");
+  tfVelToBase(command_source_frame_);
   try
   {
     double roll{}, pitch{}, yaw{};
-    quatToRPY(robot_state_handle_.lookupTransform("base_link", "yaw", ros::Time(0)).transform.rotation, roll, pitch,
-              yaw);
+    quatToRPY(robot_state_handle_.lookupTransform("base_link", command_source_frame_, ros::Time(0)).transform.rotation,
+              roll, pitch, yaw);
 
     double angle[4] = { -0.785, 0.785, 2.355, -2.355 };
     double off_set = 0.0;
@@ -256,7 +256,7 @@ void ChassisBase<T...>::gyro()
 
     recovery();
   }
-  tfVelToBase(follow_source_frame_);
+  tfVelToBase(command_source_frame_);
 }
 
 template <typename... T>
@@ -269,6 +269,7 @@ void ChassisBase<T...>::raw()
 
     recovery();
   }
+  tfVelToBase(command_source_frame_);
 }
 
 template <typename... T>


### PR DESCRIPTION
使得工程能够实时根据yaw的位置（或者指定的command frame） 而行走，即在操作手的视角中始终wasd是对应的方向。
1.无法使用follow 因为用follow底盘会跟随云台动，很容易工程狂转，不适合
2. gyro模式也无法使用，gyro是小陀螺模式，在chassisgimbal中的逻辑中，只要进入了gyro模式，车立马开始小陀螺，因此在键鼠中不适合用gyro。
3. raw模式 只需要增加到command 的tf变化即可，虽然可能有点违背的raw模式 是未经过处理的命令？ 但这样子的话 已经测试过是没有问题的。
现在使用的就是raw模式 但是增加了tf的变化