### PR TITLE
Add balance auto exit block

### DIFF
--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -8,6 +8,7 @@
 #include <controller_interface/multi_interface_controller.h>
 #include <hardware_interface/imu_sensor_interface.h>
 #include <hardware_interface/joint_command_interface.h>
+#include <rm_msgs/BalanceState.h>
 
 #include "rm_chassis_controllers/chassis_base.h"
 
@@ -51,7 +52,8 @@ private:
   hardware_interface::ImuSensorHandle imu_handle_;
   hardware_interface::JointHandle left_wheel_joint_handle_, right_wheel_joint_handle_,
       left_momentum_block_joint_handle_, right_momentum_block_joint_handle_;
-  ros::Publisher state_pub_;
+  typedef std::shared_ptr<realtime_tools::RealtimePublisher<rm_msgs::BalanceState>> RtpublisherPtr;
+  RtpublisherPtr state_pub_;
 };
 
 }  // namespace rm_chassis_controllers

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -18,7 +18,7 @@ using Eigen::Matrix;
 class BalanceController : public ChassisBase<rm_control::RobotStateInterface, hardware_interface::ImuSensorInterface,
                                              hardware_interface::EffortJointInterface>
 {
-  enum BalanceState
+  enum BalanceMode
   {
     NORMAL,
     BLOCK

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -45,7 +45,7 @@ private:
 
   int balance_state_;
   ros::Time block_time_, last_block_time_;
-  double block_duration_, block_angle_, block_effort_, anti_block_effort_, block_overtime_;
+  double block_duration_, block_velocity_, block_effort_, anti_block_effort_, block_overtime_;
   bool balance_state_changed_ = false, maybe_block_ = false;
 
   hardware_interface::ImuSensorHandle imu_handle_;

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -17,6 +17,12 @@ using Eigen::Matrix;
 class BalanceController : public ChassisBase<rm_control::RobotStateInterface, hardware_interface::ImuSensorInterface,
                                              hardware_interface::EffortJointInterface>
 {
+  enum balanceState
+  {
+    NORMAL,
+    BLOCK
+  };
+
 public:
   BalanceController() = default;
   bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) override;
@@ -36,6 +42,11 @@ private:
   double position_offset_ = 0.;
   double position_clear_threshold_ = 0.;
   double yaw_des_ = 0;
+
+  int balance_state_;
+  ros::Time block_time_, last_block_time_;
+  double block_duration_, block_angle_, block_effort_, anti_block_effort_, block_overtime_;
+  bool balance_state_changed_ = false, maybe_block_ = false;
 
   hardware_interface::ImuSensorHandle imu_handle_;
   hardware_interface::JointHandle left_wheel_joint_handle_, right_wheel_joint_handle_,

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -45,7 +45,7 @@ private:
 
   int balance_state_;
   ros::Time block_time_, last_block_time_;
-  double block_duration_, block_velocity_, block_effort_, anti_block_effort_, block_overtime_;
+  double block_angle_, block_duration_, block_velocity_, block_effort_, anti_block_effort_, block_overtime_;
   bool balance_state_changed_ = false, maybe_block_ = false;
 
   hardware_interface::ImuSensorHandle imu_handle_;

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -17,7 +17,7 @@ using Eigen::Matrix;
 class BalanceController : public ChassisBase<rm_control::RobotStateInterface, hardware_interface::ImuSensorInterface,
                                              hardware_interface::EffortJointInterface>
 {
-  enum balanceState
+  enum BalanceState
   {
     NORMAL,
     BLOCK

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -30,6 +30,8 @@ public:
 
 private:
   void moveJoint(const ros::Time& time, const ros::Duration& period) override;
+  void normal(const ros::Time& time, const ros::Duration& period);
+  void block(const ros::Time& time, const ros::Duration& period);
   geometry_msgs::Twist odometry() override;
   static const int STATE_DIM = 10;
   static const int CONTROL_DIM = 4;
@@ -52,8 +54,11 @@ private:
   hardware_interface::ImuSensorHandle imu_handle_;
   hardware_interface::JointHandle left_wheel_joint_handle_, right_wheel_joint_handle_,
       left_momentum_block_joint_handle_, right_momentum_block_joint_handle_;
+
   typedef std::shared_ptr<realtime_tools::RealtimePublisher<rm_msgs::BalanceState>> RtpublisherPtr;
   RtpublisherPtr state_pub_;
+  geometry_msgs::Vector3 angular_vel_base_;
+  double roll_, pitch_, yaw_;
 };
 
 }  // namespace rm_chassis_controllers

--- a/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
+++ b/rm_chassis_controllers/include/rm_chassis_controllers/balance.h
@@ -46,7 +46,7 @@ private:
   double position_clear_threshold_ = 0.;
   double yaw_des_ = 0;
 
-  int balance_state_;
+  int balance_mode_;
   ros::Time block_time_, last_block_time_;
   double block_angle_, block_duration_, block_velocity_, block_effort_, anti_block_effort_, block_overtime_;
   bool balance_state_changed_ = false, maybe_block_ = false;

--- a/rm_chassis_controllers/src/balance.cpp
+++ b/rm_chassis_controllers/src/balance.cpp
@@ -314,7 +314,7 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   ROS_INFO_STREAM("K of LQR:" << k_);
 
   state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::BalanceState>(root_nh, "/state", 100));
-  balance_state_ = BalanceState::NORMAL;
+  balance_state_ = BalanceMode::NORMAL;
 
   return true;
 }
@@ -363,7 +363,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
   quatToRPY(toMsg(odom2base).rotation, roll_, pitch_, yaw_);
 
   // Check block
-  if (balance_state_ != BalanceState::BLOCK)
+  if (balance_state_ != BalanceMode::BLOCK)
   {
     if (std::abs(pitch_) > block_angle_ &&
         (std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
@@ -378,7 +378,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       }
       if ((time - block_time_).toSec() >= block_duration_)
       {
-        balance_state_ = BalanceState::BLOCK;
+        balance_state_ = BalanceMode::BLOCK;
         balance_state_changed_ = true;
         ROS_INFO("[balance] Exit NOMAl");
       }
@@ -391,12 +391,12 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
 
   switch (balance_state_)
   {
-    case BalanceState::NORMAL:
+    case BalanceMode::NORMAL:
     {
       normal(time, period);
       break;
     }
-    case BalanceState::BLOCK:
+    case BalanceMode::BLOCK:
     {
       block(time, period);
       break;
@@ -476,7 +476,7 @@ void BalanceController::block(const ros::Time& time, const ros::Duration& period
   }
   if ((ros::Time::now() - last_block_time_).toSec() > block_overtime_)
   {
-    balance_state_ = BalanceState::NORMAL;
+    balance_state_ = BalanceMode::NORMAL;
     balance_state_changed_ = true;
     ROS_INFO("[balance] Exit BLOCK");
   }

--- a/rm_chassis_controllers/src/balance.cpp
+++ b/rm_chassis_controllers/src/balance.cpp
@@ -314,7 +314,7 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   ROS_INFO_STREAM("K of LQR:" << k_);
 
   state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::BalanceState>(root_nh, "/state", 100));
-  balance_state_ = BalanceMode::NORMAL;
+  balance_mode_ = BalanceMode::NORMAL;
 
   return true;
 }
@@ -363,7 +363,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
   quatToRPY(toMsg(odom2base).rotation, roll_, pitch_, yaw_);
 
   // Check block
-  if (balance_state_ != BalanceMode::BLOCK)
+  if (balance_mode_ != BalanceMode::BLOCK)
   {
     if (std::abs(pitch_) > block_angle_ &&
         (std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
@@ -378,7 +378,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       }
       if ((time - block_time_).toSec() >= block_duration_)
       {
-        balance_state_ = BalanceMode::BLOCK;
+        balance_mode_ = BalanceMode::BLOCK;
         balance_state_changed_ = true;
         ROS_INFO("[balance] Exit NOMAl");
       }
@@ -389,7 +389,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
     }
   }
 
-  switch (balance_state_)
+  switch (balance_mode_)
   {
     case BalanceMode::NORMAL:
     {
@@ -476,7 +476,7 @@ void BalanceController::block(const ros::Time& time, const ros::Duration& period
   }
   if ((ros::Time::now() - last_block_time_).toSec() > block_overtime_)
   {
-    balance_state_ = BalanceMode::NORMAL;
+    balance_mode_ = BalanceMode::NORMAL;
     balance_state_changed_ = true;
     ROS_INFO("[balance] Exit BLOCK");
   }

--- a/rm_chassis_controllers/src/balance.cpp
+++ b/rm_chassis_controllers/src/balance.cpp
@@ -109,6 +109,11 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
     ROS_ERROR("Params block_duration doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
     return false;
   }
+  if (!controller_nh.getParam("block_angle", block_angle_))
+  {
+    ROS_ERROR("Params block_angle doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
   if (!controller_nh.getParam("block_effort", block_effort_))
   {
     ROS_ERROR("Params block_speed doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
@@ -361,7 +366,8 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
   // Check block
   if (balance_state_ != balanceState::BLOCK)
   {
-    if ((std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
+    if (std::abs(pitch) > block_angle_ &&
+        (std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
             block_effort_ &&
         (left_wheel_joint_handle_.getVelocity() < block_velocity_ ||
          right_wheel_joint_handle_.getVelocity() < block_velocity_))

--- a/rm_chassis_controllers/src/balance.cpp
+++ b/rm_chassis_controllers/src/balance.cpp
@@ -314,7 +314,7 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   ROS_INFO_STREAM("K of LQR:" << k_);
 
   state_pub_ = root_nh.advertise<rm_msgs::BalanceState>("/state", 10);
-  balance_state_ = balanceState::NORMAL;
+  balance_state_ = BalanceState::NORMAL;
 
   return true;
 }
@@ -364,7 +364,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
   quatToRPY(toMsg(odom2base).rotation, roll, pitch, yaw);
 
   // Check block
-  if (balance_state_ != balanceState::BLOCK)
+  if (balance_state_ != BalanceState::BLOCK)
   {
     if (std::abs(pitch) > block_angle_ &&
         (std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
@@ -379,7 +379,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       }
       if ((time - block_time_).toSec() >= block_duration_)
       {
-        balance_state_ = balanceState::BLOCK;
+        balance_state_ = BalanceState::BLOCK;
         balance_state_changed_ = true;
         ROS_INFO("[balance] Exit NOMAl");
       }
@@ -392,7 +392,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
 
   switch (balance_state_)
   {
-    case balanceState::NORMAL:
+    case BalanceState::NORMAL:
     {
       if (balance_state_changed_)
       {
@@ -417,7 +417,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       auto x = x_;
       x(0) -= position_des_;
       x(1) = angles::shortest_angular_distance(yaw_des_, x_(1));
-      if (state_ != GYRO)
+      if (state_ != RAW)
         x(5) -= vel_cmd_.x;
       x(6) -= vel_cmd_.z;
       if (std::abs(x(0) + position_offset_) > position_clear_threshold_)
@@ -450,7 +450,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       right_momentum_block_joint_handle_.setCommand(u(3));
       break;
     }
-    case balanceState::BLOCK:
+    case BalanceState::BLOCK:
     {
       if (balance_state_changed_)
       {
@@ -461,7 +461,7 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
       }
       if ((ros::Time::now() - last_block_time_).toSec() > block_overtime_)
       {
-        balance_state_ = balanceState::NORMAL;
+        balance_state_ = BalanceState::NORMAL;
         balance_state_changed_ = true;
         ROS_INFO("[balance] Exit BLOCK");
       }

--- a/rm_chassis_controllers/src/balance.cpp
+++ b/rm_chassis_controllers/src/balance.cpp
@@ -104,6 +104,31 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
     ROS_ERROR("Params wheel_base_ doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
     return false;
   }
+  if (!controller_nh.getParam("block_duration", block_duration_))
+  {
+    ROS_ERROR("Params block_duration doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
+  if (!controller_nh.getParam("block_effort", block_effort_))
+  {
+    ROS_ERROR("Params block_speed doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
+  if (!controller_nh.getParam("block_angle", block_angle_))
+  {
+    ROS_ERROR("Params block_effort doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
+  if (!controller_nh.getParam("anti_block_effort", anti_block_effort_))
+  {
+    ROS_ERROR("Params anti_block_effort doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
+  if (!controller_nh.getParam("block_overtime", block_overtime_))
+  {
+    ROS_ERROR("Params block_overtime doesn't given (namespace: %s)", controller_nh.getNamespace().c_str());
+    return false;
+  }
   controller_nh.getParam("position_offset", position_offset_);
   controller_nh.getParam("position_clear_threshold", position_clear_threshold_);
 
@@ -119,9 +144,13 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   {
     ROS_ASSERT(q[i].getType() == XmlRpc::XmlRpcValue::TypeDouble || q[i].getType() == XmlRpc::XmlRpcValue::TypeInt);
     if (q[i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
+    {
       q_(i, i) = static_cast<double>(q[i]);
+    }
     else if (q[i].getType() == XmlRpc::XmlRpcValue::TypeInt)
+    {
       q_(i, i) = static_cast<int>(q[i]);
+    }
   }
   // Check and get R
   ROS_ASSERT(r.getType() == XmlRpc::XmlRpcValue::TypeArray);
@@ -130,9 +159,13 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   {
     ROS_ASSERT(r[i].getType() == XmlRpc::XmlRpcValue::TypeDouble || r[i].getType() == XmlRpc::XmlRpcValue::TypeInt);
     if (r[i].getType() == XmlRpc::XmlRpcValue::TypeDouble)
+    {
       r_(i, i) = static_cast<double>(r[i]);
+    }
     else if (r[i].getType() == XmlRpc::XmlRpcValue::TypeInt)
+    {
       r_(i, i) = static_cast<int>(r[i]);
+    }
   }
 
   // Continuous model \dot{x} = A x + B u
@@ -276,6 +309,8 @@ bool BalanceController::init(hardware_interface::RobotHW* robot_hw, ros::NodeHan
   ROS_INFO_STREAM("K of LQR:" << k_);
 
   state_pub_ = root_nh.advertise<rm_msgs::BalanceState>("/state", 10);
+  balance_state_ = balanceState::NORMAL;
+
   return true;
 }
 
@@ -319,56 +354,119 @@ void BalanceController::moveJoint(const ros::Time& time, const ros::Duration& pe
   odom2imu.setOrigin(odom2imu_origin);
   odom2imu.setRotation(odom2imu_quaternion);
   odom2base = odom2imu * imu2base;
+
   double roll, pitch, yaw;
   quatToRPY(toMsg(odom2base).rotation, roll, pitch, yaw);
-  x_[5] = ((left_wheel_joint_handle_.getVelocity() + right_wheel_joint_handle_.getVelocity()) / 2 -
-           imu_handle_.getAngularVelocity()[1]) *
-          wheel_radius_;
-  x_[0] += x_[5] * period.toSec();
-  x_[1] = yaw;
-  x_[2] = pitch;
-  x_[3] = left_momentum_block_joint_handle_.getPosition();
-  x_[4] = right_momentum_block_joint_handle_.getPosition();
-  x_[6] = angular_vel_base.z;
-  x_[7] = angular_vel_base.y;
-  x_[8] = left_momentum_block_joint_handle_.getVelocity();
-  x_[9] = right_momentum_block_joint_handle_.getVelocity();
-  yaw_des_ += vel_cmd_.z * period.toSec();
-  position_des_ += vel_cmd_.x * period.toSec();
-  Eigen::Matrix<double, CONTROL_DIM, 1> u;
-  auto x = x_;
-  x(0) -= position_des_;
-  x(1) = angles::shortest_angular_distance(yaw_des_, x_(1));
-  x(5) -= vel_cmd_.x;
-  x(6) -= vel_cmd_.z;
-  if (std::abs(x(0) + position_offset_) > position_clear_threshold_)
-  {
-    x_[0] = 0.;
-    position_des_ = position_offset_;
-  }
-  u = k_ * (-x);
-  rm_msgs::BalanceState state;
-  state.header.stamp = time;
-  state.x = x(0);
-  state.phi = x(1);
-  state.theta = x(2);
-  state.x_b_l = x(3);
-  state.x_b_r = x(4);
-  state.x_dot = x(5);
-  state.phi_dot = x(6);
-  state.theta_dot = x(7);
-  state.x_b_l_dot = x(8);
-  state.x_b_r_dot = x(9);
-  state.T_l = u(0);
-  state.T_r = u(1);
-  state.f_b_l = u(2);
-  state.f_b_r = u(3);
-  state_pub_.publish(state);
 
-  left_wheel_joint_handle_.setCommand(u(0));
-  right_wheel_joint_handle_.setCommand(u(1));
-  left_momentum_block_joint_handle_.setCommand(u(2));
-  right_momentum_block_joint_handle_.setCommand(u(3));
+  // Check block
+  if (balance_state_ != balanceState::BLOCK)
+  {
+    if ((std::abs(left_wheel_joint_handle_.getEffort()) + std::abs(right_wheel_joint_handle_.getEffort())) / 2. >
+            block_effort_ &&
+        (left_wheel_joint_handle_.getVelocity() < 0.5 || right_wheel_joint_handle_.getVelocity() < 0.5))
+    {
+      if (!maybe_block_)
+      {
+        block_time_ = time;
+        maybe_block_ = true;
+      }
+      if ((time - block_time_).toSec() >= block_duration_)
+      {
+        balance_state_ = balanceState::BLOCK;
+        balance_state_changed_ = true;
+        ROS_INFO("[balance] Exit NOMAl");
+      }
+    }
+    else
+    {
+      maybe_block_ = false;
+    }
+  }
+
+  switch (balance_state_)
+  {
+    case balanceState::NORMAL:
+    {
+      if (balance_state_changed_)
+      {
+        ROS_INFO("[balance] Enter NOMAl");
+        balance_state_changed_ = false;
+      }
+      x_[5] = ((left_wheel_joint_handle_.getVelocity() + right_wheel_joint_handle_.getVelocity()) / 2 -
+               imu_handle_.getAngularVelocity()[1]) *
+              wheel_radius_;
+      x_[0] += x_[5] * period.toSec();
+      x_[1] = yaw;
+      x_[2] = pitch;
+      x_[3] = left_momentum_block_joint_handle_.getPosition();
+      x_[4] = right_momentum_block_joint_handle_.getPosition();
+      x_[6] = angular_vel_base.z;
+      x_[7] = angular_vel_base.y;
+      x_[8] = left_momentum_block_joint_handle_.getVelocity();
+      x_[9] = right_momentum_block_joint_handle_.getVelocity();
+      yaw_des_ += vel_cmd_.z * period.toSec();
+      position_des_ += vel_cmd_.x * period.toSec();
+      Eigen::Matrix<double, CONTROL_DIM, 1> u;
+      auto x = x_;
+      x(0) -= position_des_;
+      x(1) = angles::shortest_angular_distance(yaw_des_, x_(1));
+      x(5) -= vel_cmd_.x;
+      x(6) -= vel_cmd_.z;
+      if (std::abs(x(0) + position_offset_) > position_clear_threshold_)
+      {
+        x_[0] = 0.;
+        position_des_ = position_offset_;
+      }
+      u = k_ * (-x);
+      rm_msgs::BalanceState state;
+      state.header.stamp = time;
+      state.x = x(0);
+      state.phi = x(1);
+      state.theta = x(2);
+      state.x_b_l = x(3);
+      state.x_b_r = x(4);
+      state.x_dot = x(5);
+      state.phi_dot = x(6);
+      state.theta_dot = x(7);
+      state.x_b_l_dot = x(8);
+      state.x_b_r_dot = x(9);
+      state.T_l = u(0);
+      state.T_r = u(1);
+      state.f_b_l = u(2);
+      state.f_b_r = u(3);
+      state_pub_.publish(state);
+
+      left_wheel_joint_handle_.setCommand(u(0));
+      right_wheel_joint_handle_.setCommand(u(1));
+      left_momentum_block_joint_handle_.setCommand(u(2));
+      right_momentum_block_joint_handle_.setCommand(u(3));
+      break;
+    }
+    case balanceState::BLOCK:
+    {
+      if (balance_state_changed_)
+      {
+        ROS_INFO("[balance] Enter BLOCK");
+        balance_state_changed_ = false;
+
+        last_block_time_ = ros::Time::now();
+      }
+      if ((ros::Time::now() - last_block_time_).toSec() > block_overtime_)
+      {
+        balance_state_ = balanceState::NORMAL;
+        balance_state_changed_ = true;
+        ROS_INFO("[balance] Exit BLOCK");
+      }
+      else
+      {
+        left_momentum_block_joint_handle_.setCommand(pitch > 0 ? -80 : 80);
+        right_momentum_block_joint_handle_.setCommand(pitch > 0 ? -80 : 80);
+        left_wheel_joint_handle_.setCommand(pitch > 0 ? -anti_block_effort_ : anti_block_effort_);
+        right_wheel_joint_handle_.setCommand(pitch > 0 ? -anti_block_effort_ : anti_block_effort_);
+      }
+      break;
+    }
+  }
 }
 
 geometry_msgs::Twist BalanceController::odometry()


### PR DESCRIPTION
针对场上平衡步兵可能在上电重启后在墙角卡住的情况，加入了自动退出卡住状态的代码。判断条件是轮子的扭矩大于一定值，轮子速度小于一定值且倾角大于一定值(针对倒下的情况)，以上情况在持续一段时间后进入卡住状态，车体会向后运动一小段距离以退出可能卡住的区域，之后再尝试重新起立。

相关参数:
    block_duration: 0.8
    block_angle: 0.28
    block_effort: 2.0
    block_velocity: 0.08
    anti_block_effort: 1.5
    block_overtime: 0.2

相关pr:  [rm_config](https://github.com/rm-controls/rm_config/pull/27)