### PR TITLE
Remove unnecessary variables

### DIFF
--- a/rm_calibration_controllers/include/rm_calibration_controllers/mechanical_calibration_controller.h
+++ b/rm_calibration_controllers/include/rm_calibration_controllers/mechanical_calibration_controller.h
@@ -78,7 +78,7 @@ private:
     MOVING_POSITIVE = 3,
     MOVING_NEGATIVE,
   };
-  int state_{}, countdown_{};
+  int countdown_{};
   double velocity_threshold_{}, position_threshold_{};
   double positive_position_{}, negative_position_{}, target_position_{};
   bool is_return_{}, is_center_{};

--- a/rm_calibration_controllers/src/calibration_base.cpp
+++ b/rm_calibration_controllers/src/calibration_base.cpp
@@ -38,6 +38,7 @@ void CalibrationBase<T...>::starting(const ros::Time& time)
 {
   actuator_.setCalibrated(false);
   state_ = INITIALIZED;
+  calibration_success_ = false;
   if (actuator_.getCalibrated())
     ROS_INFO("Joint %s will be recalibrated, but was already calibrated at offset %f",
              velocity_ctrl_.getJointName().c_str(), actuator_.getOffset());


### PR DESCRIPTION
删除机械限位校准控制器头文件中的成员变量state_，因为在基类中已经定义，这里不需要定义。
同时在starting时，将calibration_success设成false，因为现在程序里面，校准完成一次后，这个值会一直是true。