### PR TITLE
Rewrite the stopping function and set calibration success to false in stopping function

### DIFF
--- a/rm_calibration_controllers/include/rm_calibration_controllers/calibration_base.h
+++ b/rm_calibration_controllers/include/rm_calibration_controllers/calibration_base.h
@@ -41,6 +41,7 @@ public:
    * @param time The current time.
    */
   void starting(const ros::Time& time) override;
+  void stopping(const ros::Time& time) override;
 
 protected:
   /** @brief Provide a service to know the state of target actuators.

--- a/rm_calibration_controllers/src/calibration_base.cpp
+++ b/rm_calibration_controllers/src/calibration_base.cpp
@@ -38,10 +38,15 @@ void CalibrationBase<T...>::starting(const ros::Time& time)
 {
   actuator_.setCalibrated(false);
   state_ = INITIALIZED;
-  calibration_success_ = false;
   if (actuator_.getCalibrated())
     ROS_INFO("Joint %s will be recalibrated, but was already calibrated at offset %f",
              velocity_ctrl_.getJointName().c_str(), actuator_.getOffset());
+}
+
+template <typename... T>
+void CalibrationBase<T...>::stopping(const ros::Time& time)
+{
+  calibration_success_ = false;
 }
 
 template <typename... T>


### PR DESCRIPTION
1. 现象：使用键鼠操作时，按下校准键，出现校准仍未完成但校准控制器就被停止的情况。
2. 原因：当按下校准键时，会调用校准队列中的reset函数，这个函数将一个指针指向首个CalibrationService类对象、把switched设为false，并调用setCalibratedFalse函数将response.isCalibrated设为false；这个函数执行完成后，首次调用校准队列中的update函数，会开启校准控制器，此时会调用校准控制器的starting函数，在starting函数中会把一个bool变量calibration_success_设为false，calibration_success_是用来给resp.is_calibrated赋值的；第二次调用校准队列的update函数时，会调用一次callService函数，但是此时控制器中的starting函数可能还没有跑到将calibration_success_设为false那一句，那么此时得到的response.is_calibrated就是true，会误以为校准已经完成。这种情况下，当第三次调用校准队列的update函数时，就会把校准控制器关闭。导致校准未完成就被停止。
3. 解决方法：在校准控制器中重写stopping函数，并在stopping函数中将calibration_success_设为false，这样每次校准完成、关闭校准控制器后，calibration_success_都会被设成false，下一次调用reset函数来开启校准控制器时就不会出现上述现象。