### PR TITLE
Add multi_dof_controller.

### DIFF
--- a/multi_dof_controller/CMakeLists.txt
+++ b/multi_dof_controller/CMakeLists.txt
@@ -1,0 +1,83 @@
+cmake_minimum_required(VERSION 3.10)
+project(multi_dof_controller)
+
+## Use C++14
+set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+## Find catkin macros and libraries
+## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
+## is used, also find other catkin packages
+add_definitions(-Wall -Werror)
+
+find_package(catkin REQUIRED
+        COMPONENTS
+        roscpp
+        geometry_msgs
+
+        rm_common
+
+        controller_interface
+        effort_controllers
+        )
+
+
+################################################
+## Declare ROS dynamic reconfigure parameters ##
+################################################
+
+
+catkin_package(
+        INCLUDE_DIRS
+        include
+        LIBRARIES
+        CATKIN_DEPENDS
+        roscpp
+        geometry_msgs
+
+        rm_common
+
+        effort_controllers
+        LIBRARIES ${PROJECT_NAME}
+)
+
+###########
+## Build ##
+###########
+
+## Specify additional locations of header files
+## Your package locations should be listed before other locations
+include_directories(
+     include
+     ${catkin_INCLUDE_DIRS}
+)
+## Declare a cpp library
+add_library(${PROJECT_NAME} src/multi_dof_controller.cpp )
+
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES})
+
+
+#############
+## Install ##
+#############
+
+## Mark executables and/or libraries for installation
+install(DIRECTORY include/
+        DESTINATION ${CATKIN_GLOBAL_INCLUDE_DESTINATION}
+        FILES_MATCHING PATTERN "*.h"
+        )
+
+install(TARGETS multi_dof_controller
+        ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
+        RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        )
+
+install(FILES multi_dof_controller_plugins.xml
+        DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
+        )
+
+
+#############
+## Testing ##
+#############

--- a/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
+++ b/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
@@ -1,0 +1,67 @@
+//
+// Created by lsy on 23-3-15.
+//
+
+#pragma once
+
+#include <effort_controllers/joint_position_controller.h>
+#include <effort_controllers/joint_velocity_controller.h>
+#include <controller_interface/multi_interface_controller.h>
+#include <hardware_interface/joint_command_interface.h>
+#include <rm_common/hardware_interface/robot_state_interface.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <rm_msgs/MultiDofCmd.h>
+
+namespace multi_dof_controller
+{
+struct Joint
+{
+  std::string joint_name_;
+  effort_controllers::JointPositionController* ctrl_position_;
+  effort_controllers::JointVelocityController* ctrl_velocity_;
+};
+struct Motion
+{
+  std::string motion_name_;
+  double position_per_step_;
+  double velocity_max_speed_;
+  std::vector<bool> fixed_direction_;
+  std::vector<double> position_;
+  std::vector<double> velocity_;
+};
+
+class Controller : public controller_interface::MultiInterfaceController<rm_control::RobotStateInterface,
+                                                                         hardware_interface::EffortJointInterface>
+{
+public:
+  Controller() = default;
+  bool init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh) override;
+  void starting(const ros::Time& time) override;
+  void update(const ros::Time& time, const ros::Duration& period) override;
+
+private:
+  void judgeMotionGroup();
+  void commandCB(const rm_msgs::MultiDofCmdPtr& msg);
+  double judgeInputDirection(double value, bool fixed_direction);
+  void position(const ros::Time& time, const ros::Duration& period);
+  void velocity(const ros::Time& time, const ros::Duration& period);
+
+  int state_ = rm_msgs::MultiDofCmd::VELOCITY;
+  bool state_changed_{}, position_change_{ true };
+  double time_out_, position_tolerance_;
+  std::vector<Joint> joints_{};
+  std::vector<Motion> motions_{};
+  std::vector<std::string> motion_group_{};
+  std::vector<double> motion_group_values_{}, targets_{};
+  std::vector<hardware_interface::JointHandle> joint_handles_{};
+
+  ros::Time start_time_;
+  ros::Subscriber cmd_multi_dof_sub_;
+  realtime_tools::RealtimeBuffer<rm_msgs::MultiDofCmd> cmd_rt_buffer_{};
+  hardware_interface::EffortJointInterface* effort_joint_interface_{};
+  effort_controllers::JointPositionController ctrl_yaw_, ctrl_pitch_;
+
+  rm_msgs::MultiDofCmd cmd_multi_dof_{};
+};
+
+}  // namespace multi_dof_controller

--- a/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
+++ b/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
@@ -23,7 +23,6 @@ struct Joint
 struct Motion
 {
   std::string motion_name_;
-  double position_per_step_;
   double velocity_max_speed_;
   std::vector<bool> fixed_direction_;
   std::vector<double> position_;

--- a/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
+++ b/multi_dof_controller/include/multi_dof_controller/multi_dof_controller.h
@@ -40,7 +40,7 @@ public:
   void update(const ros::Time& time, const ros::Duration& period) override;
 
 private:
-  void judgeMotionGroup();
+  void judgeMotionGroup(rm_msgs::MultiDofCmd cmd_multi_dof);
   void commandCB(const rm_msgs::MultiDofCmdPtr& msg);
   double judgeInputDirection(double value, bool fixed_direction);
   void position(const ros::Time& time, const ros::Duration& period);
@@ -53,15 +53,10 @@ private:
   std::vector<Motion> motions_{};
   std::vector<std::string> motion_group_{};
   std::vector<double> motion_group_values_{}, targets_{};
-  std::vector<hardware_interface::JointHandle> joint_handles_{};
 
   ros::Time start_time_;
   ros::Subscriber cmd_multi_dof_sub_;
   realtime_tools::RealtimeBuffer<rm_msgs::MultiDofCmd> cmd_rt_buffer_{};
-  hardware_interface::EffortJointInterface* effort_joint_interface_{};
-  effort_controllers::JointPositionController ctrl_yaw_, ctrl_pitch_;
-
-  rm_msgs::MultiDofCmd cmd_multi_dof_{};
 };
 
 }  // namespace multi_dof_controller

--- a/multi_dof_controller/multi_dof_controller_plugins.xml
+++ b/multi_dof_controller/multi_dof_controller_plugins.xml
@@ -1,0 +1,11 @@
+<library path="lib/libmulti_dof_controller">
+
+    <class name="multi_dof_controller/Controller" type="multi_dof_controller::Controller"
+           base_class_type="controller_interface::ControllerBase">
+        <description>
+            The Controller is RoboMaster robot Multi Dof controller. It expects a EffortJointInterface type of hardware
+            interface.
+        </description>
+    </class>
+
+</library>

--- a/multi_dof_controller/package.xml
+++ b/multi_dof_controller/package.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0"?>
+<package format="2">
+  <name>multi_dof_controller</name>
+  <version>0.0.0</version>
+  <description>The multi_dof_controller package</description>
+  <license>BSD</license>
+  <maintainer email="2028238109@qq.com">lsy</maintainer>
+
+  <!-- buildtool_depend: dependencies of the build process -->
+  <buildtool_depend>catkin</buildtool_depend>
+  <!-- depend: build, export, and execution dependency -->
+  <depend>roscpp</depend>
+
+  <depend>rm_common</depend>
+  <depend>geometry_msgs</depend>
+
+  <depend>controller_interface</depend>
+  <depend>effort_controllers</depend>
+
+
+  <export>
+    <!-- Other tools can request additional information be placed here -->
+    <controller_interface plugin="${prefix}/multi_dof_controller_plugins.xml"/>
+  </export>
+</package>

--- a/multi_dof_controller/src/multi_dof_controller.cpp
+++ b/multi_dof_controller/src/multi_dof_controller.cpp
@@ -1,0 +1,185 @@
+//
+// Created by lsy on 23-3-15.
+//
+
+#include "multi_dof_controller/multi_dof_controller.h"
+
+#include <string>
+#include <rm_common/ros_utilities.h>
+#include <pluginlib/class_list_macros.hpp>
+
+namespace multi_dof_controller
+{
+bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& root_nh, ros::NodeHandle& controller_nh)
+{
+  XmlRpc::XmlRpcValue joints;
+  controller_nh.getParam("joints", joints);
+  position_tolerance_ = getParam(controller_nh, "position_tolerance", 0.01);
+  time_out_ = getParam(controller_nh, "time_out", 1);
+  ROS_ASSERT(joints.getType() == XmlRpc::XmlRpcValue::TypeStruct);
+  effort_joint_interface_ = robot_hw->get<hardware_interface::EffortJointInterface>();
+  for (const auto& joint : joints)
+  {
+    Joint j{ .joint_name_ = joint.first,
+             .ctrl_position_ = new effort_controllers::JointPositionController(),
+             .ctrl_velocity_ = new effort_controllers::JointVelocityController() };
+    ros::NodeHandle nh_position = ros::NodeHandle(controller_nh, "joints/" + joint.first + "/position");
+    ros::NodeHandle nh_velocity = ros::NodeHandle(controller_nh, "joints/" + joint.first + "/velocity");
+    if (!j.ctrl_position_->init(effort_joint_interface_, nh_position) ||
+        !j.ctrl_velocity_->init(effort_joint_interface_, nh_velocity))
+      return false;
+    joint_handles_.push_back(j.ctrl_position_->joint_);
+    joint_handles_.push_back(j.ctrl_velocity_->joint_);
+    joints_.push_back(j);
+  }
+  XmlRpc::XmlRpcValue motions;
+  controller_nh.getParam("motions", motions);
+  for (const auto& motion : motions)
+  {
+    Motion m{ .motion_name_ = motion.first,
+              .position_per_step_ = xmlRpcGetDouble(motion.second["position_per_step"]),
+              .velocity_max_speed_ = xmlRpcGetDouble(motion.second["velocity_max_speed"]) };
+    for (int i = 0; i < (int)motion.second["position"].size(); ++i)
+    {
+      ROS_ASSERT(motion.second["position"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble);
+      ROS_ASSERT(motion.second["velocity"][i].getType() == XmlRpc::XmlRpcValue::TypeDouble);
+      ROS_ASSERT(motion.second["fixed_direction"][i].getType() == XmlRpc::XmlRpcValue::TypeInt);
+      m.position_.push_back(xmlRpcGetDouble(motion.second["position"][i]));
+      m.velocity_.push_back(xmlRpcGetDouble(motion.second["velocity"][i]));
+      m.fixed_direction_.push_back(xmlRpcGetDouble(motion.second["fixed_direction"][i]));
+    }
+    motions_.push_back(m);
+  }
+  cmd_multi_dof_sub_ = controller_nh.subscribe("command", 1, &Controller::commandCB, this);
+  return true;
+}
+
+void Controller::starting(const ros::Time& /*unused*/)
+{
+  state_ = rm_msgs::MultiDofCmd::VELOCITY;
+  state_changed_ = true;
+}
+
+void Controller::update(const ros::Time& time, const ros::Duration& period)
+{
+  motion_group_.clear();
+  motion_group_values_.clear();
+  cmd_multi_dof_ = *cmd_rt_buffer_.readFromRT();
+  judgeMotionGroup();
+  if (state_ != cmd_multi_dof_.mode)
+  {
+    state_ = cmd_multi_dof_.mode;
+    state_changed_ = true;
+  }
+  switch (state_)
+  {
+    case rm_msgs::MultiDofCmd::VELOCITY:
+      velocity(time, period);
+      break;
+    case rm_msgs::MultiDofCmd::POSITION:
+      position(time, period);
+      break;
+  }
+}
+
+void Controller::velocity(const ros::Time& time, const ros::Duration& period)
+{
+  position_change_ = true;
+  if (state_changed_)
+  {
+    state_changed_ = false;
+    ROS_INFO("[Multi_Dof] VELOCITY");
+  }
+  std::vector<double> results((double)joints_.size(), 0);
+  for (int i = 0; i < (int)joints_.size(); ++i)
+  {
+    for (int j = 0; j < (int)motion_group_.size(); ++j)
+    {
+      for (int k = 0; k < (int)motions_.size(); ++k)
+      {
+        if (motions_[k].motion_name_ == motion_group_[j])
+          results[i] += judgeInputDirection(motion_group_values_[j], motions_[k].fixed_direction_[i]) *
+                        motions_[k].velocity_max_speed_ * motions_[k].velocity_[i];
+      }
+    }
+  }
+  for (int i = 0; i < (int)joints_.size(); ++i)
+  {
+    joints_[i].ctrl_velocity_->setCommand(results[i]);
+    joints_[i].ctrl_velocity_->update(time, period);
+  }
+}
+void Controller::position(const ros::Time& time, const ros::Duration& period)
+{
+  if (state_changed_)
+  {
+    state_changed_ = false;
+    ROS_INFO("[Multi_Dof] POSITION");
+  }
+  if (position_change_)
+  {
+    start_time_ = time;
+    std::vector<double> current_positions((double)joints_.size(), 0);
+    std::vector<double> results((double)joints_.size(), 0);
+    targets_ = results;
+    for (int i = 0; i < (int)joints_.size(); ++i)
+    {
+      current_positions[i] = (joints_[i].ctrl_position_->getPosition());
+      for (int j = 0; j < (int)motion_group_.size(); ++j)
+      {
+        for (int k = 0; k < (int)motions_.size(); ++k)
+        {
+          if (motions_[k].motion_name_ == motion_group_[j])
+          {
+            results[i] += judgeInputDirection(motion_group_values_[j], motions_[k].fixed_direction_[i]) /
+                          motions_[k].position_per_step_ * motions_[k].position_[i];
+          }
+        }
+      }
+      position_change_ = false;
+      targets_[i] = results[i] + current_positions[i];
+    }
+  }
+  double arrived_joint_num = 0;
+  for (int i = 0; i < (int)joints_.size(); ++i)
+  {
+    if (targets_[i] - position_tolerance_ <= joints_[i].ctrl_position_->getPosition() &&
+        targets_[i] + position_tolerance_ >= joints_[i].ctrl_position_->getPosition())
+    {
+      arrived_joint_num++;
+      targets_[i] = joints_[i].ctrl_position_->getPosition();
+    }
+    joints_[i].ctrl_position_->setCommand(targets_[i]);
+    joints_[i].ctrl_position_->update(time, period);
+  }
+  if (arrived_joint_num == (int)joints_.size() || (time - start_time_).toSec() >= time_out_)
+    position_change_ = true;
+}
+
+double Controller::judgeInputDirection(double value, bool fixed_direction)
+{
+  if (fixed_direction)
+    value = abs(value);
+  return value;
+}
+void Controller::judgeMotionGroup()
+{
+  std::vector<std::string> motion_names = { "linear_x", "linear_y", "linear_z", "angular_x", "angular_y", "angular_z" };
+  std::vector<double> motion_values = { cmd_multi_dof_.linear.x,  cmd_multi_dof_.linear.y,  cmd_multi_dof_.linear.z,
+                                        cmd_multi_dof_.angular.x, cmd_multi_dof_.angular.y, cmd_multi_dof_.angular.z };
+  for (int i = 0; i < (int)motion_names.size(); i++)
+  {
+    if (abs(motion_values[i]))
+    {
+      motion_group_.push_back(motion_names[i]);
+      motion_group_values_.push_back(motion_values[i]);
+    }
+  }
+}
+
+void Controller::commandCB(const rm_msgs::MultiDofCmdPtr& msg)
+{
+  cmd_rt_buffer_.writeFromNonRT(*msg);
+}
+}  // namespace multi_dof_controller
+PLUGINLIB_EXPORT_CLASS(multi_dof_controller::Controller, controller_interface::ControllerBase)

--- a/multi_dof_controller/src/multi_dof_controller.cpp
+++ b/multi_dof_controller/src/multi_dof_controller.cpp
@@ -36,7 +36,6 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
   for (const auto& motion : motions)
   {
     Motion m{ .motion_name_ = motion.first,
-              .position_per_step_ = xmlRpcGetDouble(motion.second["position_per_step"]),
               .velocity_max_speed_ = xmlRpcGetDouble(motion.second["velocity_max_speed"]) };
     for (int i = 0; i < (int)motion.second["position"].size(); ++i)
     {
@@ -131,8 +130,8 @@ void Controller::position(const ros::Time& time, const ros::Duration& period)
         {
           if (motions_[k].motion_name_ == motion_group_[j])
           {
-            results[i] += judgeInputDirection(motion_group_values_[j], motions_[k].fixed_direction_[i]) /
-                          motions_[k].position_per_step_ * motions_[k].position_[i];
+            results[i] += judgeInputDirection(motion_group_values_[j], motions_[k].fixed_direction_[i]) *
+                          motions_[k].position_[i];
           }
         }
       }
@@ -158,9 +157,7 @@ void Controller::position(const ros::Time& time, const ros::Duration& period)
 
 double Controller::judgeInputDirection(double value, bool fixed_direction)
 {
-  if (fixed_direction)
-    value = abs(value);
-  return value;
+  return fixed_direction ? abs(value) : value;
 }
 void Controller::judgeMotionGroup(rm_msgs::MultiDofCmd cmd_multi_dof)
 {

--- a/rm_controllers/package.xml
+++ b/rm_controllers/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <exec_depend>gpio_controller</exec_depend>
   <exec_depend>mimic_joint_controller</exec_depend>
+  <exec_depend>multi_dof_controller</exec_depend>
   <exec_depend>rm_calibration_controllers</exec_depend>
   <exec_depend>rm_chassis_controllers</exec_depend>
   <exec_depend>rm_gimbal_controllers</exec_depend>


### PR DESCRIPTION
## Pr目的：

 增加新的控制器方便翻转接入到动作组之间。

### 功能说明：

 控制器有两个state，可以选择速度控制和位置控制。其中位置控制目的为了让矿石转动指定的角度或者长度。

### 配套参数文件：
```
  multi_dof_controller:
    type: multi_dof_controller/Controller
    joints:
      pitch_front_joint:
        position:
          joint: pitch_front_joint
          pid: { p: 0.02, i: 0., d: 0.1, i_clamp_max: 0., i_clamp_min: 0., antiwindup: true, publish_state: true }
        velocity:
          joint: pitch_front_joint
          pid: { p: 0.02, i: 0., d: 0, i_clamp_max: 0., i_clamp_min: 0., antiwindup: true, publish_state: true }m
   motions:
      angular_y:
        velocity: [1.,1.,1.,1.]
        velocity_max_speed: 5
        position: [1.,1.,1.,1.]
        position_per_step: 1
        fixed_direction: [0,0,0,0]
```
#### 参数说明：

-  joints:控制器用到的电机，可以变化数量，初始化内容放到.h中JOINTS结构体中
-  motions:控制器包含的动作名称（可包括x,y,z,r,p,y)初始化内容放到.h中MOTIONS结构体中
-  velocity:单个动作的电机速度配置（大小方向）
-  fixed_direction：考虑到某些动作下，有些电机仅仅为辅助作用，旋转方向固定，不因输入值而改变（例如目前工程 pitch翻转时候，下层的两个电机同向转动来翻动pitch，上层两个电机持续往下让矿石吃到下面两个电机的摩擦力）
-  position_per_step：位置控制下，每一步转的度数或距离（对应到 position_config中每一个电机为了让矿石转这一步自身需要转动的角度。

### 目前情况：

 在工程上经过测试可以满足需求

