### PR TITLE
Modify shooter controller to achieve function of adjusting friction wheel speed by key

### DIFF
--- a/rm_shooter_controllers/cfg/Shooter.cfg
+++ b/rm_shooter_controllers/cfg/Shooter.cfg
@@ -13,11 +13,6 @@ gen.add("anti_block_angle", double_t, 0, "Trigger anti block angle", 0.35, 0.0, 
 gen.add("anti_block_threshold", double_t, 0, "Trigger anti block error threshold", 0.05, 0.0, 0.2)
 gen.add("forward_push_threshold",double_t,0,"The trigger position threshold to push forward in push mode",0.01,0.0,1)
 gen.add("exit_push_threshold",double_t,0,"The trigger position threshold to exit push mode",0.02,0.0,1)
-gen.add("qd_10", double_t, 0, "Friction wheel rotation speed when bullet speed is 10m/s", 300, 0.0, 9999)
-gen.add("qd_15", double_t, 0, "Friction wheel rotation speed when bullet speed is 15m/s", 300, 0.0, 9999)
-gen.add("qd_16", double_t, 0, "Friction wheel rotation speed when bullet speed is 16m/s", 300, 0.0, 9999)
-gen.add("qd_18", double_t, 0, "Friction wheel rotation speed when bullet speed is 18m/s", 300, 0.0, 9999)
-gen.add("qd_30", double_t, 0, "Friction wheel rotation speed when bullet speed is 30m/s", 300, 0.0, 9999)
-gen.add("lf_extra_rotat_speed", double_t, 0, "Lefrt friction extra rotation speed", -200, 0.0, 200)
+gen.add("extra_rotat_speed", double_t, 0, "Lefrt friction extra rotation speed", -200, 0.0, 200)
 
 exit(gen.generate(PACKAGE, "shooter", "Shooter"))

--- a/rm_shooter_controllers/cfg/Shooter.cfg
+++ b/rm_shooter_controllers/cfg/Shooter.cfg
@@ -13,6 +13,6 @@ gen.add("anti_block_angle", double_t, 0, "Trigger anti block angle", 0.35, 0.0, 
 gen.add("anti_block_threshold", double_t, 0, "Trigger anti block error threshold", 0.05, 0.0, 0.2)
 gen.add("forward_push_threshold",double_t,0,"The trigger position threshold to push forward in push mode",0.01,0.0,1)
 gen.add("exit_push_threshold",double_t,0,"The trigger position threshold to exit push mode",0.02,0.0,1)
-gen.add("extra_rotat_speed", double_t, 0, "Lefrt friction extra rotation speed", -200, 0.0, 200)
+gen.add("extra_wheel_speed", double_t, 0, "Friction wheel extra rotation speed", 0.0, -999, 999)
 
 exit(gen.generate(PACKAGE, "shooter", "Shooter"))

--- a/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
+++ b/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
@@ -57,7 +57,7 @@ struct Config
 {
   double block_effort, block_speed, block_duration, block_overtime, anti_block_angle, anti_block_threshold,
       forward_push_threshold, exit_push_threshold;
-  double extra_rotat_speed;
+  double extra_wheel_speed;
 };
 
 class Controller : public controller_interface::MultiInterfaceController<hardware_interface::EffortJointInterface,
@@ -86,7 +86,7 @@ private:
   effort_controllers::JointVelocityController ctrl_friction_l_, ctrl_friction_r_;
   effort_controllers::JointPositionController ctrl_trigger_;
   int push_per_rotation_{};
-  double push_qd_threshold_{};
+  double push_wheel_speed_threshold_{};
   bool dynamic_reconfig_initialized_ = false;
   bool state_changed_ = false;
   bool maybe_block_ = false;

--- a/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
+++ b/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
@@ -82,7 +82,8 @@ private:
     cmd_rt_buffer_.writeFromNonRT(*msg);
   }
   void reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/);
-  bool extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req, rm_msgs::ExtraFrictionWheelSpeed::Response& res);
+  bool extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req,
+                                 rm_msgs::ExtraFrictionWheelSpeed::Response& res);
 
   hardware_interface::EffortJointInterface* effort_joint_interface_{};
   effort_controllers::JointVelocityController ctrl_friction_l_, ctrl_friction_r_;

--- a/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
+++ b/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
@@ -48,6 +48,7 @@
 #include <rm_shooter_controllers/ShooterConfig.h>
 #include <rm_msgs/ShootCmd.h>
 #include <rm_msgs/ShootState.h>
+#include <rm_msgs/ShooterSpeed.h>
 
 #include <utility>
 
@@ -81,12 +82,14 @@ private:
     cmd_rt_buffer_.writeFromNonRT(*msg);
   }
   void reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/);
+  bool changeStatusCB(rm_msgs::ShooterSpeed::Request& req, rm_msgs::ShooterSpeed::Response& res);
 
   hardware_interface::EffortJointInterface* effort_joint_interface_{};
   effort_controllers::JointVelocityController ctrl_friction_l_, ctrl_friction_r_;
   effort_controllers::JointPositionController ctrl_trigger_;
   int push_per_rotation_{};
   double push_qd_threshold_{};
+  double extra_speed_{};
   bool dynamic_reconfig_initialized_ = false;
   bool state_changed_ = false;
   bool maybe_block_ = false;
@@ -106,6 +109,7 @@ private:
   rm_msgs::ShootCmd cmd_;
   std::shared_ptr<realtime_tools::RealtimePublisher<rm_msgs::ShootState>> shoot_state_pub_;
   ros::Subscriber cmd_subscriber_;
+  ros::ServiceServer shoot_speed_srv_;
   dynamic_reconfigure::Server<rm_shooter_controllers::ShooterConfig>* d_srv_{};
 };
 

--- a/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
+++ b/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
@@ -48,7 +48,7 @@
 #include <rm_shooter_controllers/ShooterConfig.h>
 #include <rm_msgs/ShootCmd.h>
 #include <rm_msgs/ShootState.h>
-#include <rm_msgs/ShooterSpeed.h>
+#include <rm_msgs/ExtraFrictionWheelSpeed.h>
 
 #include <utility>
 
@@ -82,14 +82,14 @@ private:
     cmd_rt_buffer_.writeFromNonRT(*msg);
   }
   void reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/);
-  bool changeStatusCB(rm_msgs::ShooterSpeed::Request& req, rm_msgs::ShooterSpeed::Response& res);
+  bool extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req, rm_msgs::ExtraFrictionWheelSpeed::Response& res);
 
   hardware_interface::EffortJointInterface* effort_joint_interface_{};
   effort_controllers::JointVelocityController ctrl_friction_l_, ctrl_friction_r_;
   effort_controllers::JointPositionController ctrl_trigger_;
   int push_per_rotation_{};
   double push_qd_threshold_{};
-  double extra_speed_{};
+  double extra_friction_wheel_speed_{};
   bool dynamic_reconfig_initialized_ = false;
   bool state_changed_ = false;
   bool maybe_block_ = false;
@@ -109,7 +109,7 @@ private:
   rm_msgs::ShootCmd cmd_;
   std::shared_ptr<realtime_tools::RealtimePublisher<rm_msgs::ShootState>> shoot_state_pub_;
   ros::Subscriber cmd_subscriber_;
-  ros::ServiceServer shoot_speed_srv_;
+  ros::ServiceServer extra_friction_wheel_speed_srv_;
   dynamic_reconfigure::Server<rm_shooter_controllers::ShooterConfig>* d_srv_{};
 };
 

--- a/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
+++ b/rm_shooter_controllers/include/rm_shooter_controllers/standard.h
@@ -48,7 +48,6 @@
 #include <rm_shooter_controllers/ShooterConfig.h>
 #include <rm_msgs/ShootCmd.h>
 #include <rm_msgs/ShootState.h>
-#include <rm_msgs/ExtraFrictionWheelSpeed.h>
 
 #include <utility>
 
@@ -58,7 +57,7 @@ struct Config
 {
   double block_effort, block_speed, block_duration, block_overtime, anti_block_angle, anti_block_threshold,
       forward_push_threshold, exit_push_threshold;
-  double qd_10, qd_15, qd_16, qd_18, qd_30, lf_extra_rotat_speed;
+  double extra_rotat_speed;
 };
 
 class Controller : public controller_interface::MultiInterfaceController<hardware_interface::EffortJointInterface,
@@ -82,15 +81,12 @@ private:
     cmd_rt_buffer_.writeFromNonRT(*msg);
   }
   void reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/);
-  bool extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req,
-                                 rm_msgs::ExtraFrictionWheelSpeed::Response& res);
 
   hardware_interface::EffortJointInterface* effort_joint_interface_{};
   effort_controllers::JointVelocityController ctrl_friction_l_, ctrl_friction_r_;
   effort_controllers::JointPositionController ctrl_trigger_;
   int push_per_rotation_{};
   double push_qd_threshold_{};
-  double extra_friction_wheel_speed_{};
   bool dynamic_reconfig_initialized_ = false;
   bool state_changed_ = false;
   bool maybe_block_ = false;
@@ -110,7 +106,6 @@ private:
   rm_msgs::ShootCmd cmd_;
   std::shared_ptr<realtime_tools::RealtimePublisher<rm_msgs::ShootState>> shoot_state_pub_;
   ros::Subscriber cmd_subscriber_;
-  ros::ServiceServer extra_friction_wheel_speed_srv_;
   dynamic_reconfigure::Server<rm_shooter_controllers::ShooterConfig>* d_srv_{};
 };
 

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -62,7 +62,8 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
   push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
 
-  extra_friction_wheel_speed_srv_ = controller_nh.advertiseService("extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
+  extra_friction_wheel_speed_srv_ =
+      controller_nh.advertiseService("extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
   // Init dynamic reconfigure
@@ -249,7 +250,7 @@ void Controller::normalize()
 }
 
 bool Controller::extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req,
-                                rm_msgs::ExtraFrictionWheelSpeed::Response& res)
+                                           rm_msgs::ExtraFrictionWheelSpeed::Response& res)
 {
   extra_friction_wheel_speed_ = req.extra_speed;
   res.is_success = true;

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -52,10 +52,10 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
               .anti_block_threshold = getParam(controller_nh, "anti_block_threshold", 0.),
               .forward_push_threshold = getParam(controller_nh, "forward_push_threshold", 0.1),
               .exit_push_threshold = getParam(controller_nh, "exit_push_threshold", 0.1),
-              .extra_rotat_speed = getParam(controller_nh, "lf_extra_rotat_speed", 0.) };
+              .extra_wheel_speed = getParam(controller_nh, "extra_wheel_speed", 0.) };
   config_rt_buffer.initRT(config_);
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
-  push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
+  push_wheel_speed_threshold_ = getParam(controller_nh, "push_wheel_speed_threshold", 0.);
 
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
@@ -157,10 +157,11 @@ void Controller::push(const ros::Time& time, const ros::Duration& period)
     state_changed_ = false;
     ROS_INFO("[Shooter] Enter PUSH");
   }
-  if ((cmd_.qd_des == 0. || (ctrl_friction_l_.joint_.getVelocity() >= push_qd_threshold_ * ctrl_friction_l_.command_ &&
-                             ctrl_friction_l_.joint_.getVelocity() > M_PI &&
-                             ctrl_friction_r_.joint_.getVelocity() <= push_qd_threshold_ * ctrl_friction_r_.command_ &&
-                             ctrl_friction_r_.joint_.getVelocity() < -M_PI)) &&
+  if ((cmd_.wheel_speed == 0. ||
+       (ctrl_friction_l_.joint_.getVelocity() >= push_wheel_speed_threshold_ * ctrl_friction_l_.command_ &&
+        ctrl_friction_l_.joint_.getVelocity() > M_PI &&
+        ctrl_friction_r_.joint_.getVelocity() <= push_wheel_speed_threshold_ * ctrl_friction_r_.command_ &&
+        ctrl_friction_r_.joint_.getVelocity() < -M_PI)) &&
       (time - last_shoot_time_).toSec() >= 1. / cmd_.hz)
   {  // Time to shoot!!!
     if (std::fmod(std::abs(ctrl_trigger_.command_struct_.position_ - ctrl_trigger_.getPosition()), 2. * M_PI) <
@@ -218,8 +219,8 @@ void Controller::block(const ros::Time& time, const ros::Duration& period)
 
 void Controller::setSpeed(const rm_msgs::ShootCmd& cmd)
 {
-  ctrl_friction_l_.setCommand(cmd_.qd_des + config_.extra_rotat_speed);
-  ctrl_friction_r_.setCommand(-cmd_.qd_des - config_.extra_rotat_speed);
+  ctrl_friction_l_.setCommand(cmd_.wheel_speed + config_.extra_wheel_speed);
+  ctrl_friction_r_.setCommand(-cmd_.wheel_speed - config_.extra_wheel_speed);
 }
 
 void Controller::normalize()
@@ -242,7 +243,7 @@ void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint3
     config.anti_block_threshold = init_config.anti_block_threshold;
     config.forward_push_threshold = init_config.forward_push_threshold;
     config.exit_push_threshold = init_config.exit_push_threshold;
-    config.extra_rotat_speed = init_config.extra_rotat_speed;
+    config.extra_wheel_speed = init_config.extra_wheel_speed;
     dynamic_reconfig_initialized_ = true;
   }
   Config config_non_rt{ .block_effort = config.block_effort,
@@ -253,7 +254,7 @@ void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint3
                         .anti_block_threshold = config.anti_block_threshold,
                         .forward_push_threshold = config.forward_push_threshold,
                         .exit_push_threshold = config.exit_push_threshold,
-                        .extra_rotat_speed = config.extra_rotat_speed };
+                        .extra_wheel_speed = config.extra_wheel_speed };
   config_rt_buffer.writeFromNonRT(config_non_rt);
 }
 

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -62,7 +62,7 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
   push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
 
-  extra_friction_wheel_speed_srv_ = controller_nh.advertiseService("/extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
+  extra_friction_wheel_speed_srv_ = controller_nh.advertiseService("extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
   // Init dynamic reconfigure

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -62,6 +62,7 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
   push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
 
+  shoot_speed_srv_ = controller_nh.advertiseService("/shooter_speed", &Controller::changeStatusCB, this);
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
   // Init dynamic reconfigure
@@ -237,14 +238,21 @@ void Controller::setSpeed(const rm_msgs::ShootCmd& cmd)
     qd_des = config_.qd_30;
   else
     qd_des = 0.;
-  ctrl_friction_l_.setCommand(qd_des + config_.lf_extra_rotat_speed);
-  ctrl_friction_r_.setCommand(-qd_des);
+  ctrl_friction_l_.setCommand(qd_des + config_.lf_extra_rotat_speed + extra_speed_);
+  ctrl_friction_r_.setCommand(-qd_des - extra_speed_);
 }
 
 void Controller::normalize()
 {
   double push_angle = 2. * M_PI / static_cast<double>(push_per_rotation_);
   ctrl_trigger_.setCommand(push_angle * std::floor((ctrl_trigger_.joint_.getPosition() + 0.01) / push_angle));
+}
+
+bool Controller::changeStatusCB(rm_msgs::ShooterSpeed::Request& req, rm_msgs::ShooterSpeed::Response& res)
+{
+  extra_speed_ = req.shooter_speed;
+  res.is_success = true;
+  return true;
 }
 
 void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/)

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -62,7 +62,7 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
   push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
 
-  shoot_speed_srv_ = controller_nh.advertiseService("/shooter_speed", &Controller::changeStatusCB, this);
+  extra_friction_wheel_speed_srv_ = controller_nh.advertiseService("/extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
   // Init dynamic reconfigure
@@ -238,8 +238,8 @@ void Controller::setSpeed(const rm_msgs::ShootCmd& cmd)
     qd_des = config_.qd_30;
   else
     qd_des = 0.;
-  ctrl_friction_l_.setCommand(qd_des + config_.lf_extra_rotat_speed + extra_speed_);
-  ctrl_friction_r_.setCommand(-qd_des - extra_speed_);
+  ctrl_friction_l_.setCommand(qd_des + config_.lf_extra_rotat_speed + extra_friction_wheel_speed_);
+  ctrl_friction_r_.setCommand(-qd_des - extra_friction_wheel_speed_);
 }
 
 void Controller::normalize()
@@ -248,9 +248,10 @@ void Controller::normalize()
   ctrl_trigger_.setCommand(push_angle * std::floor((ctrl_trigger_.joint_.getPosition() + 0.01) / push_angle));
 }
 
-bool Controller::changeStatusCB(rm_msgs::ShooterSpeed::Request& req, rm_msgs::ShooterSpeed::Response& res)
+bool Controller::extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req,
+                                rm_msgs::ExtraFrictionWheelSpeed::Response& res)
 {
-  extra_speed_ = req.shooter_speed;
+  extra_friction_wheel_speed_ = req.extra_speed;
   res.is_success = true;
   return true;
 }

--- a/rm_shooter_controllers/src/standard.cpp
+++ b/rm_shooter_controllers/src/standard.cpp
@@ -52,18 +52,11 @@ bool Controller::init(hardware_interface::RobotHW* robot_hw, ros::NodeHandle& ro
               .anti_block_threshold = getParam(controller_nh, "anti_block_threshold", 0.),
               .forward_push_threshold = getParam(controller_nh, "forward_push_threshold", 0.1),
               .exit_push_threshold = getParam(controller_nh, "exit_push_threshold", 0.1),
-              .qd_10 = getParam(controller_nh, "qd_10", 0.),
-              .qd_15 = getParam(controller_nh, "qd_15", 0.),
-              .qd_16 = getParam(controller_nh, "qd_16", 0.),
-              .qd_18 = getParam(controller_nh, "qd_18", 0.),
-              .qd_30 = getParam(controller_nh, "qd_30", 0.),
-              .lf_extra_rotat_speed = getParam(controller_nh, "lf_extra_rotat_speed", 0.) };
+              .extra_rotat_speed = getParam(controller_nh, "lf_extra_rotat_speed", 0.) };
   config_rt_buffer.initRT(config_);
   push_per_rotation_ = getParam(controller_nh, "push_per_rotation", 0);
   push_qd_threshold_ = getParam(controller_nh, "push_qd_threshold", 0.);
 
-  extra_friction_wheel_speed_srv_ =
-      controller_nh.advertiseService("extra_friction_wheel_speed", &Controller::extraFrictionWheelSpeedCB, this);
   cmd_subscriber_ = controller_nh.subscribe<rm_msgs::ShootCmd>("command", 1, &Controller::commandCB, this);
   shoot_state_pub_.reset(new realtime_tools::RealtimePublisher<rm_msgs::ShootState>(controller_nh, "state", 10));
   // Init dynamic reconfigure
@@ -164,11 +157,10 @@ void Controller::push(const ros::Time& time, const ros::Duration& period)
     state_changed_ = false;
     ROS_INFO("[Shooter] Enter PUSH");
   }
-  if ((cmd_.speed == cmd_.SPEED_ZERO_FOR_TEST ||
-       (ctrl_friction_l_.joint_.getVelocity() >= push_qd_threshold_ * ctrl_friction_l_.command_ &&
-        ctrl_friction_l_.joint_.getVelocity() > M_PI &&
-        ctrl_friction_r_.joint_.getVelocity() <= push_qd_threshold_ * ctrl_friction_r_.command_ &&
-        ctrl_friction_r_.joint_.getVelocity() < -M_PI)) &&
+  if ((cmd_.qd_des == 0. || (ctrl_friction_l_.joint_.getVelocity() >= push_qd_threshold_ * ctrl_friction_l_.command_ &&
+                             ctrl_friction_l_.joint_.getVelocity() > M_PI &&
+                             ctrl_friction_r_.joint_.getVelocity() <= push_qd_threshold_ * ctrl_friction_r_.command_ &&
+                             ctrl_friction_r_.joint_.getVelocity() < -M_PI)) &&
       (time - last_shoot_time_).toSec() >= 1. / cmd_.hz)
   {  // Time to shoot!!!
     if (std::fmod(std::abs(ctrl_trigger_.command_struct_.position_ - ctrl_trigger_.getPosition()), 2. * M_PI) <
@@ -226,35 +218,14 @@ void Controller::block(const ros::Time& time, const ros::Duration& period)
 
 void Controller::setSpeed(const rm_msgs::ShootCmd& cmd)
 {
-  double qd_des;
-  if (cmd_.speed == cmd_.SPEED_10M_PER_SECOND)
-    qd_des = config_.qd_10;
-  else if (cmd_.speed == cmd_.SPEED_15M_PER_SECOND)
-    qd_des = config_.qd_15;
-  else if (cmd_.speed == cmd_.SPEED_16M_PER_SECOND)
-    qd_des = config_.qd_16;
-  else if (cmd_.speed == cmd_.SPEED_18M_PER_SECOND)
-    qd_des = config_.qd_18;
-  else if (cmd_.speed == cmd_.SPEED_30M_PER_SECOND)
-    qd_des = config_.qd_30;
-  else
-    qd_des = 0.;
-  ctrl_friction_l_.setCommand(qd_des + config_.lf_extra_rotat_speed + extra_friction_wheel_speed_);
-  ctrl_friction_r_.setCommand(-qd_des - extra_friction_wheel_speed_);
+  ctrl_friction_l_.setCommand(cmd_.qd_des + config_.extra_rotat_speed);
+  ctrl_friction_r_.setCommand(-cmd_.qd_des - config_.extra_rotat_speed);
 }
 
 void Controller::normalize()
 {
   double push_angle = 2. * M_PI / static_cast<double>(push_per_rotation_);
   ctrl_trigger_.setCommand(push_angle * std::floor((ctrl_trigger_.joint_.getPosition() + 0.01) / push_angle));
-}
-
-bool Controller::extraFrictionWheelSpeedCB(rm_msgs::ExtraFrictionWheelSpeed::Request& req,
-                                           rm_msgs::ExtraFrictionWheelSpeed::Response& res)
-{
-  extra_friction_wheel_speed_ = req.extra_speed;
-  res.is_success = true;
-  return true;
 }
 
 void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint32_t /*level*/)
@@ -271,12 +242,7 @@ void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint3
     config.anti_block_threshold = init_config.anti_block_threshold;
     config.forward_push_threshold = init_config.forward_push_threshold;
     config.exit_push_threshold = init_config.exit_push_threshold;
-    config.qd_10 = init_config.qd_10;
-    config.qd_15 = init_config.qd_15;
-    config.qd_16 = init_config.qd_16;
-    config.qd_18 = init_config.qd_18;
-    config.qd_30 = init_config.qd_30;
-    config.lf_extra_rotat_speed = init_config.lf_extra_rotat_speed;
+    config.extra_rotat_speed = init_config.extra_rotat_speed;
     dynamic_reconfig_initialized_ = true;
   }
   Config config_non_rt{ .block_effort = config.block_effort,
@@ -287,12 +253,7 @@ void Controller::reconfigCB(rm_shooter_controllers::ShooterConfig& config, uint3
                         .anti_block_threshold = config.anti_block_threshold,
                         .forward_push_threshold = config.forward_push_threshold,
                         .exit_push_threshold = config.exit_push_threshold,
-                        .qd_10 = config.qd_10,
-                        .qd_15 = config.qd_15,
-                        .qd_16 = config.qd_16,
-                        .qd_18 = config.qd_18,
-                        .qd_30 = config.qd_30,
-                        .lf_extra_rotat_speed = config.lf_extra_rotat_speed };
+                        .extra_rotat_speed = config.extra_rotat_speed };
   config_rt_buffer.writeFromNonRT(config_non_rt);
 }
 

--- a/rm_shooter_controllers/test/shooter_config_template.yaml
+++ b/rm_shooter_controllers/test/shooter_config_template.yaml
@@ -12,12 +12,10 @@ controllers:
       joint: "trigger_joint"
       pid: { p: 50.0, i: 0.0, d: 1.5, i_clamp_max: 0.0, i_clamp_min: 0.0, antiwindup: true, publish_state: true }
     push_per_rotation: 8
-    push_qd_threshold: 0.90
+    push_wheel_speed_threshold: 0.90
     block_effort: 0.95
     block_speed: 0.1
     block_duration: 0.05
     block_overtime: 0.5
     anti_block_angle: 0.2
     anti_block_threshold: 0.1
-    qd_15: 458.0
-    qd_30: 714.0


### PR DESCRIPTION
1. 功能实现：mamual通过按键，通过service向控制器发出一个请求，内容是摩擦轮额外的转速，控制器拿到这个值后再对摩擦轮转速进行调整，从而实现按键调整摩擦轮转速的功能
2. 对控制器进行修改，增加ServiceServer以及对应回调等，实现上述功能